### PR TITLE
Bump minor version of num dependency in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ doc = false
 
 [dependencies]
 log = "0.3"
-num = "0.1"
+num = "0.2"
 rand = "0.3"
 byteorder = "0.4"


### PR DESCRIPTION
 - bump version of num from 0.1 to 0.2, 
to remove the indirect dependency on the **deprecated rustc-serialize** crate
- **maybe it could also be directly bumped to 0.3** , which is the latest version of num, https://docs.rs/crate/num/0.3.0. I decided to only bump to 0.2 to keep the changes smaller and 0.2 has already some patch releases, and 0.3 does not have any patch releases yet.
- this change will **allow other crates to compile rust-compress to wasm** 
(currently it does not compile to wasm, because of the dependency on the rustc-serialize crate


I executed locally the 4 commands of the `.travis.yml` file, with the following cargo and rustc version:
cargo 1.45.0-nightly (258c89644 2020-04-30) , ustc 1.45.0-nightly (1836e3b42 2020-05-06) 
and got this outputs:

- `cargo build --verbose`
    Finished dev [unoptimized + debuginfo] target(s) ...
- `cargo test --verbose`
    test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
- `rustdoc --test src/lib.rs -L target`
    error[E0463]: can't find crate for `byteorder`
- `cargo doc`
    Finished dev [unoptimized + debuginfo] target(s) ...
