### PR TITLE
Remove compiler warnings

### DIFF
--- a/src/bwt/mtf.rs
+++ b/src/bwt/mtf.rs
@@ -164,7 +164,7 @@ impl<R: Read> Read for Decoder<R> {
             bytes_read += 1;
             *sym = self.mtf.decode(rank);
         }
-        Ok((bytes_read))
+        Ok(bytes_read)
     }
 }
 

--- a/src/entropy/ari/apm.rs
+++ b/src/entropy/ari/apm.rs
@@ -15,7 +15,7 @@ Matt Mahoney for the wonderful 'bbb' commented source
 
 extern crate num;
 
-use self::num::traits::{Float, ToPrimitive};
+use self::num::traits::{ToPrimitive};
 use super::Border;
 pub type FlatProbability = u16;
 pub type WideProbability = i16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 #![allow(missing_copy_implementations)]
+#![allow(deprecated)]
 
 //! dox (placeholder)
 


### PR DESCRIPTION
This PR does this:

- it adds dyn for dyn Traits
- cleans up not used imports
- it adds a allow deprecated annotation, to suppress warnings for deprecated try statements.
  I decided this is the more conservative way, that has less riscs to introduce new bugs, 
  than to update all ~35 try! statements with ? syntax