### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "compress"
 doc = false
 
 [dependencies]
-log = "0.3"
-num = "0.1"
+log = "0.4"
+num = "0.3"
 rand = "0.7"
 byteorder = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ doc = false
 [dependencies]
 log = "0.3"
 num = "0.1"
-rand = "0.3"
+rand = "0.7"
 byteorder = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ doc = false
 log = "0.4"
 num = "0.3"
 rand = "0.7"
-byteorder = "0.4"
+byteorder = "1.3"

--- a/src/bwt/mod.rs
+++ b/src/bwt/mod.rs
@@ -58,7 +58,7 @@ use std::iter::{self, Extend, repeat};
 use std::io::{self, Read, Write};
 use self::num::traits::{NumCast, ToPrimitive};
 
-use super::byteorder::{self, LittleEndian, WriteBytesExt, ReadBytesExt};
+use super::byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
 use super::{byteorder_err_to_io, ReadExact};
 
 pub mod dc;
@@ -373,8 +373,8 @@ impl<R: Read> Decoder<R> {
     fn decode_block(&mut self) -> io::Result<bool> {
         let n = match self.r.read_u32::<LittleEndian>() {
             Ok(n) => n as usize,
-            Err(byteorder::Error::Io(e)) => return Err(e),
-            Err(..) => return Ok(false) // EOF
+            Err(ref e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(false), // EOF
+            Err(e) => return Err(e),
         };
 
         self.temp.truncate(0);

--- a/src/bwt/mtf.rs
+++ b/src/bwt/mtf.rs
@@ -33,7 +33,7 @@ let result = d.read_to_end(&mut decoded).unwrap();
 use std::mem;
 use std::io::{self, Read, Write};
 
-use super::super::byteorder::{self, WriteBytesExt, ReadBytesExt};
+use super::super::byteorder::{WriteBytesExt, ReadBytesExt};
 
 pub type Symbol = u8;
 pub type Rank = u8;
@@ -158,8 +158,8 @@ impl<R: Read> Read for Decoder<R> {
         for sym in dst.iter_mut() {
             let rank = match self.r.read_u8() {
                 Ok(r) => r,
-                Err(byteorder::Error::UnexpectedEOF) => break,
-                Err(byteorder::Error::Io(e)) => return Err(e)
+                Err(ref e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e)
             };
             bytes_read += 1;
             *sym = self.mtf.decode(rank);

--- a/src/flate.rs
+++ b/src/flate.rs
@@ -490,7 +490,7 @@ impl<R: Read> Read for Decoder<R> {
 #[allow(warnings)]
 mod test {
     use std::io::{BufReader, BufWriter, Read, Write};
-    use super::super::rand::{Rand, random};
+    use super::super::rand::{random};
     use super::super::byteorder::{LittleEndian, BigEndian, WriteBytesExt, ReadBytesExt};
     use std::str;
     use super::{Decoder};

--- a/src/rle.rs
+++ b/src/rle.rs
@@ -283,7 +283,7 @@ impl<R: Read> Read for Decoder<R> {
 #[cfg(test)]
 mod test {
     use super::{Decoder, Encoder};
-    use super::super::rand::{OsRng, Rng};
+    use super::super::rand::{RngCore,rngs::OsRng};
     use std::io::{Write, Read};
     use std::iter::{Iterator, repeat};
     #[cfg(feature="unstable")]
@@ -353,11 +353,9 @@ mod test {
 
     #[test]
     fn random_roundtrips() {
-        let mut rng = OsRng::new().unwrap();
-
         for _ in 0..100 {
             let mut buf = [0; 13579];
-            rng.fill_bytes(&mut buf[..]);
+            OsRng.fill_bytes(&mut buf[..]);
             test_roundtrip(&buf);
         }
     }

--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -129,7 +129,7 @@ impl<R: Read> Read for Decoder<R> {
 #[allow(warnings)]
 mod test {
     use std::io::{BufReader, BufWriter, Read, Write};
-    use super::super::rand::{random, Rand};
+    use super::super::rand::{random};
     use super::super::byteorder::{LittleEndian, BigEndian, WriteBytesExt, ReadBytesExt};
     use std::str;
     use super::{Decoder};


### PR DESCRIPTION
This PR does this:

**increment version of rand lib to 0.7**
- minor code changes needed, mostly about import path and usage of OsRng, Rng 

**increment version of log and num lib**
- no other code changes needed, just incremented the version in cargo.toml
- Note: I decided to now upgrate directly to num 0.3, instead of only num 0.2, what I planned previously

**increment version of byteorder + add tests for updated byteorder_err_to_io function**
- middle amount of code changes, mostly about handling that byteorder does have own error class anymore
and uses std::io::Error with kind: io::ErrorKind::UnexpectedEof for Eof - errors.
- added 2 tests for the updated byteorder_err_to_io function